### PR TITLE
Fix seed validation in sd_make

### DIFF
--- a/src/sd_make.py
+++ b/src/sd_make.py
@@ -52,7 +52,7 @@ def run_pipeline(photo, mask_png, out_png,
     control_img.save(mask_png)
 
     # 2️⃣ Full render
-    gen = torch.Generator(device).manual_seed(seed) if seed else None
+    gen = torch.Generator(device).manual_seed(seed) if seed is not None else None
     w, h = Image.open(photo).size
     w8, h8 = ceil(w/8)*8, ceil(h/8)*8
 


### PR DESCRIPTION
## Summary
- handle zero correctly when seeding SD pipeline

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688127e5a0888320804e70e1880803e8